### PR TITLE
fix(toolchain): remove offset pagination parameter

### DIFF
--- a/cd-toolchain/v2.ts
+++ b/cd-toolchain/v2.ts
@@ -133,9 +133,7 @@ class CdToolchainV2 extends BaseService {
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.resourceGroupId - The resource group ID where the toolchains exist.
    * @param {number} [params.limit] - Limit the number of results.
-   * @param {number} [params.offset] - Offset the results from the beginning of the list. Cannot be used if 'start' is
-   * provided.
-   * @param {string} [params.start] - Pagination token. Cannot be used if 'offset' is provided.
+   * @param {string} [params.start] - Pagination token.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<CdToolchainV2.Response<CdToolchainV2.ToolchainCollection>>}
    */
@@ -144,7 +142,7 @@ class CdToolchainV2 extends BaseService {
   ): Promise<CdToolchainV2.Response<CdToolchainV2.ToolchainCollection>> {
     const _params = { ...params };
     const _requiredParams = ['resourceGroupId'];
-    const _validParams = ['resourceGroupId', 'limit', 'offset', 'start', 'headers'];
+    const _validParams = ['resourceGroupId', 'limit', 'start', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -153,7 +151,6 @@ class CdToolchainV2 extends BaseService {
     const query = {
       'resource_group_id': _params.resourceGroupId,
       'limit': _params.limit,
-      'offset': _params.offset,
       'start': _params.start,
     };
 
@@ -391,9 +388,7 @@ class CdToolchainV2 extends BaseService {
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.toolchainId - ID of the toolchain that tools are bound to.
    * @param {number} [params.limit] - Limit the number of results.
-   * @param {number} [params.offset] - Offset the number of results from the beginning of the list. Cannot be used if
-   * 'start' is provided.
-   * @param {string} [params.start] - Pagination token. Cannot be used if 'offset' is provided.
+   * @param {string} [params.start] - Pagination token.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<CdToolchainV2.Response<CdToolchainV2.ToolchainToolCollection>>}
    */
@@ -402,7 +397,7 @@ class CdToolchainV2 extends BaseService {
   ): Promise<CdToolchainV2.Response<CdToolchainV2.ToolchainToolCollection>> {
     const _params = { ...params };
     const _requiredParams = ['toolchainId'];
-    const _validParams = ['toolchainId', 'limit', 'offset', 'start', 'headers'];
+    const _validParams = ['toolchainId', 'limit', 'start', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -410,7 +405,6 @@ class CdToolchainV2 extends BaseService {
 
     const query = {
       'limit': _params.limit,
-      'offset': _params.offset,
       'start': _params.start,
     };
 
@@ -449,7 +443,10 @@ class CdToolchainV2 extends BaseService {
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.toolchainId - ID of the toolchain to bind the tool to.
-   * @param {string} params.toolTypeId - The unique short name of the tool that should be provisioned.
+   * @param {string} params.toolTypeId - The unique short name of the tool that should be provisioned. A table of
+   * `tool_type_id` values corresponding to each tool integration can be found in the <a
+   * href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+   * integrations page</a>.
    * @param {string} [params.name] - Name of the tool.
    * @param {JsonObject} [params.parameters] - Unique key-value pairs representing parameters to be used to create the
    * tool. A list of parameters for each tool integration can be found in the <a
@@ -606,7 +603,10 @@ class CdToolchainV2 extends BaseService {
    * @param {string} params.toolchainId - ID of the toolchain.
    * @param {string} params.toolId - ID of the tool bound to the toolchain.
    * @param {string} [params.name] - Name of the tool.
-   * @param {string} [params.toolTypeId] - The unique short name of the tool that should be provisioned or updated.
+   * @param {string} [params.toolTypeId] - The unique short name of the tool that should be provisioned or updated. A
+   * table of `tool_type_id` values corresponding to each tool integration can be found in the <a
+   * href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+   * integrations page</a>.
    * @param {JsonObject} [params.parameters] - Unique key-value pairs representing parameters to be used to create the
    * tool. A list of parameters for each tool integration can be found in the <a
    * href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
@@ -696,9 +696,7 @@ namespace CdToolchainV2 {
     resourceGroupId: string;
     /** Limit the number of results. */
     limit?: number;
-    /** Offset the results from the beginning of the list. Cannot be used if 'start' is provided. */
-    offset?: number;
-    /** Pagination token. Cannot be used if 'offset' is provided. */
+    /** Pagination token. */
     start?: string;
     headers?: OutgoingHttpHeaders;
   }
@@ -745,9 +743,7 @@ namespace CdToolchainV2 {
     toolchainId: string;
     /** Limit the number of results. */
     limit?: number;
-    /** Offset the number of results from the beginning of the list. Cannot be used if 'start' is provided. */
-    offset?: number;
-    /** Pagination token. Cannot be used if 'offset' is provided. */
+    /** Pagination token. */
     start?: string;
     headers?: OutgoingHttpHeaders;
   }
@@ -756,7 +752,11 @@ namespace CdToolchainV2 {
   export interface CreateToolParams {
     /** ID of the toolchain to bind the tool to. */
     toolchainId: string;
-    /** The unique short name of the tool that should be provisioned. */
+    /** The unique short name of the tool that should be provisioned. A table of `tool_type_id` values corresponding
+     *  to each tool integration can be found in the <a
+     *  href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+     *  integrations page</a>.
+     */
     toolTypeId: string;
     /** Name of the tool. */
     name?: string;
@@ -795,7 +795,11 @@ namespace CdToolchainV2 {
     toolId: string;
     /** Name of the tool. */
     name?: string;
-    /** The unique short name of the tool that should be provisioned or updated. */
+    /** The unique short name of the tool that should be provisioned or updated. A table of `tool_type_id` values
+     *  corresponding to each tool integration can be found in the <a
+     *  href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+     *  integrations page</a>.
+     */
     toolTypeId?: string;
     /** Unique key-value pairs representing parameters to be used to create the tool. A list of parameters for each
      *  tool integration can be found in the <a
@@ -814,11 +818,15 @@ namespace CdToolchainV2 {
   export interface ToolModel {
     /** Tool ID. */
     id: string;
-    /** Resource group where the tool can be found. */
+    /** Resource group where the tool is located. */
     resource_group_id: string;
     /** Tool CRN. */
     crn: string;
-    /** The unique name of the provisioned tool. */
+    /** The unique name of the provisioned tool. A table of `tool_type_id` values corresponding to each tool
+     *  integration can be found in the <a
+     *  href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+     *  integrations page</a>.
+     */
     tool_type_id: string;
     /** ID of toolchain which the tool is bound to. */
     toolchain_id: string;
@@ -862,7 +870,7 @@ namespace CdToolchainV2 {
     account_id: string;
     /** Toolchain region. */
     location: string;
-    /** Resource group where the toolchain can be found. */
+    /** Resource group where the toolchain is located. */
     resource_group_id: string;
     /** Toolchain CRN. */
     crn: string;
@@ -886,8 +894,6 @@ namespace CdToolchainV2 {
     total_count: number;
     /** Maximum number of toolchains returned from collection. */
     limit: number;
-    /** Offset applied to toolchains collection. Returned only if 'offset' query parameter is used. */
-    offset?: number;
     /** Information about retrieving first toolchain results from the collection. */
     first: ToolchainCollectionFirst;
     /** Information about retrieving previous toolchain results from the collection. */
@@ -942,7 +948,7 @@ namespace CdToolchainV2 {
     account_id: string;
     /** Toolchain region. */
     location: string;
-    /** Resource group where the toolchain can be found. */
+    /** Resource group where the toolchain is located. */
     resource_group_id: string;
     /** Toolchain CRN. */
     crn: string;
@@ -972,7 +978,7 @@ namespace CdToolchainV2 {
     account_id: string;
     /** Toolchain region. */
     location: string;
-    /** Resource group where the toolchain can be found. */
+    /** Resource group where the toolchain is located. */
     resource_group_id: string;
     /** Toolchain CRN. */
     crn: string;
@@ -1002,7 +1008,7 @@ namespace CdToolchainV2 {
     account_id: string;
     /** Toolchain region. */
     location: string;
-    /** Resource group where the toolchain can be found. */
+    /** Resource group where the toolchain is located. */
     resource_group_id: string;
     /** Toolchain CRN. */
     crn: string;
@@ -1024,11 +1030,15 @@ namespace CdToolchainV2 {
   export interface ToolchainTool {
     /** Tool ID. */
     id: string;
-    /** Resource group where the tool can be found. */
+    /** Resource group where the tool is located. */
     resource_group_id: string;
     /** Tool CRN. */
     crn: string;
-    /** The unique name of the provisioned tool. */
+    /** The unique name of the provisioned tool. A table of `tool_type_id` values corresponding to each tool
+     *  integration can be found in the <a
+     *  href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+     *  integrations page</a>.
+     */
     tool_type_id: string;
     /** ID of toolchain which the tool is bound to. */
     toolchain_id: string;
@@ -1058,8 +1068,6 @@ namespace CdToolchainV2 {
     limit: number;
     /** Total number of tools found in collection. */
     total_count: number;
-    /** Offset applied to tools collection. */
-    offset?: number;
     /** Information about retrieving first tool results from the collection. */
     first: ToolchainToolCollectionFirst;
     /** Information about retrieving previous tool results from the collection. */
@@ -1106,11 +1114,15 @@ namespace CdToolchainV2 {
   export interface ToolchainToolPatch {
     /** Tool ID. */
     id: string;
-    /** Resource group where the tool can be found. */
+    /** Resource group where the tool is located. */
     resource_group_id: string;
     /** Tool CRN. */
     crn: string;
-    /** The unique name of the provisioned tool. */
+    /** The unique name of the provisioned tool. A table of `tool_type_id` values corresponding to each tool
+     *  integration can be found in the <a
+     *  href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+     *  integrations page</a>.
+     */
     tool_type_id: string;
     /** ID of toolchain which the tool is bound to. */
     toolchain_id: string;
@@ -1138,11 +1150,15 @@ namespace CdToolchainV2 {
   export interface ToolchainToolPost {
     /** Tool ID. */
     id: string;
-    /** Resource group where the tool can be found. */
+    /** Resource group where the tool is located. */
     resource_group_id: string;
     /** Tool CRN. */
     crn: string;
-    /** The unique name of the provisioned tool. */
+    /** The unique name of the provisioned tool. A table of `tool_type_id` values corresponding to each tool
+     *  integration can be found in the <a
+     *  href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool
+     *  integrations page</a>.
+     */
     tool_type_id: string;
     /** ID of toolchain which the tool is bound to. */
     toolchain_id: string;

--- a/examples/cd-toolchain.v2.test.js
+++ b/examples/cd-toolchain.v2.test.js
@@ -33,7 +33,6 @@ const authHelper = require('../test/resources/auth-helper.js');
 // CD_TOOLCHAIN_URL=<service base url>
 // CD_TOOLCHAIN_AUTH_TYPE=iam
 // CD_TOOLCHAIN_APIKEY=<IAM apikey>
-// CD_TOOLCHAIN_AUTH_URL=<IAM token service base URL - omit this if using the production environment>
 //
 // These configuration properties can be exported as environment variables, or stored
 // in a configuration file and then:
@@ -148,7 +147,6 @@ describe('CdToolchainV2', () => {
     const params = {
       resourceGroupId: 'testString',
       limit: 10,
-      offset: 0,
     };
 
     const allResults = [];
@@ -239,7 +237,6 @@ describe('CdToolchainV2', () => {
     const params = {
       toolchainId: toolchainIdLink,
       limit: 10,
-      offset: 0,
     };
 
     const allResults = [];

--- a/test/integration/cd-toolchain.v2.test.js
+++ b/test/integration/cd-toolchain.v2.test.js
@@ -83,7 +83,6 @@ describe('CdToolchainV2_integration', () => {
     const params = {
       resourceGroupId: 'testString',
       limit: 1,
-      offset: 0,
       start: 'testString',
     };
 
@@ -97,7 +96,6 @@ describe('CdToolchainV2_integration', () => {
     const params = {
       resourceGroupId: 'testString',
       limit: 10,
-      offset: 0,
     };
 
     const allResults = [];
@@ -146,7 +144,6 @@ describe('CdToolchainV2_integration', () => {
     const params = {
       toolchainId: toolchainIdLink,
       limit: 1,
-      offset: 0,
       start: 'testString',
     };
 
@@ -160,7 +157,6 @@ describe('CdToolchainV2_integration', () => {
     const params = {
       toolchainId: toolchainIdLink,
       limit: 10,
-      offset: 0,
     };
 
     const allResults = [];

--- a/test/unit/cd-toolchain.v2.test.js
+++ b/test/unit/cd-toolchain.v2.test.js
@@ -155,12 +155,10 @@ describe('CdToolchainV2', () => {
         // Construct the params object for operation listToolchains
         const resourceGroupId = 'testString';
         const limit = 1;
-        const offset = 0;
         const start = 'testString';
         const listToolchainsParams = {
           resourceGroupId,
           limit,
-          offset,
           start,
         };
 
@@ -180,7 +178,6 @@ describe('CdToolchainV2', () => {
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         expect(mockRequestOptions.qs.resource_group_id).toEqual(resourceGroupId);
         expect(mockRequestOptions.qs.limit).toEqual(limit);
-        expect(mockRequestOptions.qs.offset).toEqual(offset);
         expect(mockRequestOptions.qs.start).toEqual(start);
       }
 
@@ -267,7 +264,6 @@ describe('CdToolchainV2', () => {
         const params = {
           resourceGroupId: 'testString',
           limit: 10,
-          offset: 0,
         };
         const allResults = [];
         const pager = new CdToolchainV2.ToolchainsPager(cdToolchainService, params);
@@ -284,7 +280,6 @@ describe('CdToolchainV2', () => {
         const params = {
           resourceGroupId: 'testString',
           limit: 10,
-          offset: 0,
         };
         const pager = new CdToolchainV2.ToolchainsPager(cdToolchainService, params);
         const allResults = await pager.getAll();
@@ -650,12 +645,10 @@ describe('CdToolchainV2', () => {
         // Construct the params object for operation listTools
         const toolchainId = 'testString';
         const limit = 1;
-        const offset = 0;
         const start = 'testString';
         const listToolsParams = {
           toolchainId,
           limit,
-          offset,
           start,
         };
 
@@ -674,7 +667,6 @@ describe('CdToolchainV2', () => {
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         expect(mockRequestOptions.qs.limit).toEqual(limit);
-        expect(mockRequestOptions.qs.offset).toEqual(offset);
         expect(mockRequestOptions.qs.start).toEqual(start);
         expect(mockRequestOptions.path.toolchain_id).toEqual(toolchainId);
       }
@@ -762,7 +754,6 @@ describe('CdToolchainV2', () => {
         const params = {
           toolchainId: 'testString',
           limit: 10,
-          offset: 0,
         };
         const allResults = [];
         const pager = new CdToolchainV2.ToolsPager(cdToolchainService, params);
@@ -779,7 +770,6 @@ describe('CdToolchainV2', () => {
         const params = {
           toolchainId: 'testString',
           limit: 10,
-          offset: 0,
         };
         const pager = new CdToolchainV2.ToolsPager(cdToolchainService, params);
         const allResults = await pager.getAll();


### PR DESCRIPTION
Signed-off-by: Omar Al Bastami <omar.albastami@ibm.com>

## PR summary
<!-- please include a brief summary of the changes in this PR -->
Synced with latest API changes, where `offset` query parameter has been removed from list operations.

## PR Checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Users can query toolchains or tools by providing an `offset`.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->
Users must use `start` parameter to query tools and toolchains.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Apps must no longer call list operations using `offset`, and must use `start` instead.

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
