### PR TITLE
feat(package): rename package to use @ibm-cloud scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# IBM Cloud Continuous Delivery Node.js SDK 0.3.0
+# IBM Cloud Continuous Delivery Node.js SDK
 
 [![Build Status](https://app.travis-ci.com/IBM/continuous-delivery-node-sdk.svg?branch=main)](https://app.travis-ci.com/github/IBM/continuous-delivery-node-sdk)
 [![npm](https://img.shields.io/npm/v/@ibm-cloud/continuous-delivery)](https://npmjs.com/package/@ibm-cloud/continuous-delivery)
@@ -26,7 +26,7 @@ Changes might occur which impact applications that use this SDK.
 
 <!-- toc -->
 
-- [IBM Cloud Continuous Delivery Node.js SDK 0.3.0](#ibm-cloud-continuous-delivery-nodejs-sdk-v030)
+- [IBM Cloud Continuous Delivery Node.js SDK](#ibm-cloud-continuous-delivery-nodejs-sdk)
   - [Table of Contents](#table-of-contents)
   - [Overview](#overview)
   - [Migration](#migration)
@@ -89,8 +89,6 @@ const CdTektonPipelineV2 = require("@ibm-cloud/continuous-delivery/cd-tekton-pip
 [ibm-cloud-onboarding]: http://cloud.ibm.com/registration
 
 ## Installation
-
-The current version of this SDK: 0.3.0
 
 ```sh
 npm install @ibm-cloud/continuous-delivery

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
-# IBM Cloud Continuous Delivery Node.js SDK 0.2.11
+# IBM Cloud Continuous Delivery Node.js SDK 0.3.0
 
 [![Build Status](https://app.travis-ci.com/IBM/continuous-delivery-node-sdk.svg?branch=main)](https://app.travis-ci.com/github/IBM/continuous-delivery-node-sdk)
-[![npm](https://img.shields.io/npm/v/ibm-continuous-delivery)](https://npmjs.com/package/ibm-continuous-delivery)
+[![npm](https://img.shields.io/npm/v/@ibm-cloud/continuous-delivery)](https://npmjs.com/package/@ibm-cloud/continuous-delivery)
 [![Release](https://img.shields.io/github/v/release/IBM/continuous-delivery-node-sdk)](https://github.com/IBM/continuous-delivery-node-sdk/releases/latest)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
@@ -26,9 +26,10 @@ Changes might occur which impact applications that use this SDK.
 
 <!-- toc -->
 
-- [IBM Cloud Continuous Delivery Node.js SDK 0.2.11](https://npmjs.com/package/ibm-continuous-delivery/v/0.2.11)
+- [IBM Cloud Continuous Delivery Node.js SDK 0.3.0](#ibm-cloud-continuous-delivery-nodejs-sdk-v030)
   - [Table of Contents](#table-of-contents)
   - [Overview](#overview)
+  - [Migration](#migration)
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
   - [Using the SDK](#using-the-sdk)
@@ -48,10 +49,37 @@ IBM Cloud services:
 
 Service Name | Import Path
 --- | ---
-[Toolchain API](https://cloud.ibm.com/apidocs/toolchain?code=node) | ibm-continuous-delivery/cd-toolchain/v2
-[Tekton Pipeline API](https://cloud.ibm.com/apidocs/tekton-pipeline?code=node) | ibm-continuous-delivery/cd-tektonpipeline/v2
+[Toolchain API](https://cloud.ibm.com/apidocs/toolchain?code=node) | @ibm-cloud/continuous-delivery/cd-toolchain/v2
+[Tekton Pipeline API](https://cloud.ibm.com/apidocs/tekton-pipeline?code=node) | @ibm-cloud/continuous-delivery/cd-tektonpipeline/v2
 
 Table 1. IBM Cloud services
+
+<!-- --------------------------------------------------------------- -->
+## Migration
+
+`ibm-continuous-delivery` package has been deprecated! 
+The IBM Continuous Delivery Node SDK is now available as `@ibm-cloud/continuous-delivery`.
+
+To migrate to the new package, you can use the commands listed below:
+
+```
+npm uninstall ibm-continuous-delivery
+npm install @ibm-cloud/continuous-delivery
+```
+
+You will also need to modify any references to the old package `ibm-continuous-delivery` within import/require statements so they reflect the new package `@ibm-cloud/continuous-delivery`.  Here is an example:
+
+```javascript
+
+// 'require' statements that reflect the old package name:
+const CdToolchainV2 = require("ibm-continuous-delivery/cd-toolchain/v2");
+const CdTektonPipelineV2 = require("ibm-continuous-delivery/cd-tekton-pipeline/v2");
+
+// Modify this to reflect the new package name:
+const CdToolchainV2 = require("@ibm-cloud/continuous-delivery/cd-toolchain/v2");
+const CdTektonPipelineV2 = require("@ibm-cloud/continuous-delivery/cd-tekton-pipeline/v2");
+
+```
 
 ## Prerequisites
 
@@ -62,10 +90,10 @@ Table 1. IBM Cloud services
 
 ## Installation
 
-The current version of this SDK: 0.2.11
+The current version of this SDK: 0.3.0
 
 ```sh
-npm install ibm-continuous-delivery
+npm install @ibm-cloud/continuous-delivery
 ```
 
 ## Using the SDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ibm-continuous-delivery",
+  "name": "@ibm-cloud/continuous-delivery",
   "version": "0.2.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "ibm-continuous-delivery",
+      "name": "@ibm-cloud/continuous-delivery",
       "version": "0.2.11",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ibm-continuous-delivery",
+  "name": "@ibm-cloud/continuous-delivery",
   "version": "0.2.11",
   "description": "IBM Cloud Continuous Delivery Node.js SDK",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "keywords": [
     "ibm"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "IBM Corp.",
   "scripts": {
     "clean": "rm -rf node_modules",


### PR DESCRIPTION
## PR summary
Suggested by Phil Adams as part of SDK review:
* change `ibm-continuous-delivery` package name to `continuous-delivery`, and
* move it to `@ibm-cloud` organisation scope
* update README according to the above changes
* add migration section to README
* remove version numbers from README to avoid need for manual updates in future, and possible mismatches
* add public publish setting to package.json, necessary for the org scoped package change

## PR Checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)