### PR TITLE
fix(tekton): pipelineRun trigger properties

### DIFF
--- a/cd-tekton-pipeline/v2.ts
+++ b/cd-tekton-pipeline/v2.ts
@@ -457,9 +457,9 @@ class CdTektonPipelineV2 extends BaseService {
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.pipelineId - The Tekton pipeline ID.
    * @param {string} [params.triggerName] - Trigger name.
-   * @param {Property[]} [params.triggerProperties] - An object containing string values only that provides additional
+   * @param {JsonObject} [params.triggerProperties] - An object containing string values only that provides additional
    * `text` properties, or overrides existing pipeline/trigger properties, to use for the created run.
-   * @param {Property[]} [params.secureTriggerProperties] - An object containing string values only that provides
+   * @param {JsonObject} [params.secureTriggerProperties] - An object containing string values only that provides
    * additional `secure` properties, or overrides existing `secure` pipeline/trigger properties, to use for the created
    * run.
    * @param {JsonObject} [params.triggerHeaders] - An object containing string values only that provides the request
@@ -2423,11 +2423,11 @@ namespace CdTektonPipelineV2 {
     /** An object containing string values only that provides additional `text` properties, or overrides existing
      *  pipeline/trigger properties, to use for the created run.
      */
-    triggerProperties?: Property[];
+    triggerProperties?: JsonObject;
     /** An object containing string values only that provides additional `secure` properties, or overrides existing
      *  `secure` pipeline/trigger properties, to use for the created run.
      */
-    secureTriggerProperties?: Property[];
+    secureTriggerProperties?: JsonObject;
     /** An object containing string values only that provides the request headers. Use `$(header.header_key_name)`
      *  to access it in a TriggerBinding. Most commonly used as part of a Generic Webhook to provide a verification
      *  token or signature in the request headers.
@@ -3085,11 +3085,11 @@ namespace CdTektonPipelineV2 {
     /** An object containing string values only that provides additional `text` properties, or overrides existing
      *  pipeline/trigger properties, to use for the created run.
      */
-    properties?: Property[];
+    properties?: JsonObject;
     /** An object containing string values only that provides additional `secure` properties, or overrides existing
      *  `secure` pipeline/trigger properties, to use for the created run.
      */
-    secure_properties?: Property[];
+    secure_properties?: JsonObject;
     /** An object containing string values only that provides the request headers. Use `$(header.header_key_name)`
      *  to access it in a TriggerBinding. Most commonly used as part of a Generic Webhook to provide a verification
      *  token or signature in the request headers.

--- a/examples/cd-tekton-pipeline.v2.test.js
+++ b/examples/cd-tekton-pipeline.v2.test.js
@@ -217,17 +217,11 @@ describe('CdTektonPipelineV2', () => {
 
     // Request models needed by this operation.
 
-    // Property
-    const propertyModel = {
-      name: 'testString',
-      type: 'secure',
-    };
-
     // PipelineRunTrigger
     const pipelineRunTriggerModel = {
       name: 'Manual Trigger 1',
-      properties: [propertyModel],
-      secure_properties: [propertyModel],
+      properties: { 'pipeline-debug': 'false' },
+      secure_properties: { 'secure-property-key': 'secure value' },
       headers: { source: 'api' },
       body: { message: 'hello world', enable: 'true', detail: { name: 'example' } },
     };

--- a/test/integration/cd-tekton-pipeline.v2.test.js
+++ b/test/integration/cd-tekton-pipeline.v2.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2022, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ describe('CdTektonPipelineV2_integration', () => {
 
   test('createToolchain()', async () => {
     const params = {
-      name: 'TestToolchainV2',
+      name: 'NodeIntegrationTest',
       resourceGroupId: configVars.CD_TEKTON_PIPELINE_RESOURCE_GROUP_ID,
       description: 'A sample toolchain to test the API',
     };
@@ -222,20 +222,17 @@ describe('CdTektonPipelineV2_integration', () => {
   });
 
   test('createTektonPipelineRun()', async () => {
-    const propertyModel = {
-      'textProp': 'textProp123',
+    // PipelineRunTrigger
+    const pipelineRunTriggerModel = {
+      name: 'trigger1',
+      properties: { 'pipeline-debug': 'false' },
+      secure_properties: { 'secure-property-key': 'secure value' },
+      headers: { source: 'api' },
+      body: { message: 'hello world', enable: 'true', detail: { name: 'example' } },
     };
-    const securePropertyModel = {
-      'secureProp': 'secure123',
-    };
-
     const params = {
       pipelineId: pipelineIdLink,
-      triggerName: 'trigger1',
-      triggerProperties: propertyModel,
-      secureTriggerProperties: securePropertyModel,
-      triggerHeaders: { source: 'api' },
-      triggerBody: { message: 'hello world', enable: 'true' },
+      trigger: pipelineRunTriggerModel,
     };
 
     const res = await cdTektonPipelineService.createTektonPipelineRun(params);
@@ -299,7 +296,7 @@ describe('CdTektonPipelineV2_integration', () => {
   test('createTektonPipelineProperties()', async () => {
     const params = {
       pipelineId: pipelineIdLink,
-      name: 'debug-pipeline',
+      name: 'pipeline-debug',
       type: 'text',
       value: 'prop-value-1',
     };
@@ -380,31 +377,29 @@ describe('CdTektonPipelineV2_integration', () => {
   });
 
   test('getTektonPipelineRunLogs()', async () => {
-    const params = {
+    const params1 = {
       pipelineId: pipelineIdLink,
       id: pipelineRunIdLink,
     };
 
-    const res = await cdTektonPipelineService.getTektonPipelineRunLogs(params);
-    expect(res).toBeDefined();
-    expect(res.status).toBe(200);
-    expect(res.result).toBeDefined();
-    expect(res.result.logs).toBeDefined();
-    runLogsIdLink = res.result.logs[0].id;
-  });
+    const res1 = await cdTektonPipelineService.getTektonPipelineRunLogs(params1);
+    expect(res1).toBeDefined();
+    expect(res1.status).toBe(200);
+    expect(res1.result).toBeDefined();
+    expect(res1.result.logs).toBeDefined();
+    runLogsIdLink = res1.result.logs[0].id;
 
-  test('getTektonPipelineRunLogContent()', async () => {
-    const params = {
+    const params2 = {
       pipelineId: pipelineIdLink,
       pipelineRunId: pipelineRunIdLink,
       id: runLogsIdLink,
     };
 
-    const res = await cdTektonPipelineService.getTektonPipelineRunLogContent(params);
-    expect(res).toBeDefined();
-    expect(res.status).toBe(200);
-    expect(res.result).toBeDefined();
-    expect(res.result.data).toBeDefined();
+    const res2 = await cdTektonPipelineService.getTektonPipelineRunLogContent(params2);
+    expect(res2).toBeDefined();
+    expect(res2.status).toBe(200);
+    expect(res2.result).toBeDefined();
+    expect(res2.result.data).toBeDefined();
   });
 
   test('listTektonPipelineRuns()', async () => {
@@ -473,7 +468,7 @@ describe('CdTektonPipelineV2_integration', () => {
   test('deleteTektonPipelineProperty()', async () => {
     const params = {
       pipelineId: pipelineIdLink,
-      propertyName: 'debug-pipeline',
+      propertyName: 'pipeline-debug',
     };
 
     const res = await cdTektonPipelineService.deleteTektonPipelineProperty(params);
@@ -513,6 +508,17 @@ describe('CdTektonPipelineV2_integration', () => {
     };
 
     const res = await cdTektonPipelineService.deleteTektonPipeline(params);
+    expect(res).toBeDefined();
+    expect(res.status).toBe(204);
+    expect(res.result).toBeDefined();
+  });
+
+  test('deleteToolchain()', async () => {
+    const params = {
+      toolchainId: toolchainIdLink,
+    };
+
+    const res = await cdToolchainService.deleteToolchain(params);
     expect(res).toBeDefined();
     expect(res.status).toBe(204);
     expect(res.result).toBeDefined();

--- a/test/unit/cd-tekton-pipeline.v2.test.js
+++ b/test/unit/cd-tekton-pipeline.v2.test.js
@@ -696,21 +696,11 @@ describe('CdTektonPipelineV2', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
 
-      // Property
-      const propertyModel = {
-        name: 'testString',
-        value: 'testString',
-        href: 'testString',
-        enum: ['testString'],
-        type: 'secure',
-        path: 'testString',
-      };
-
       // PipelineRunTrigger
       const pipelineRunTriggerModel = {
         name: 'Manual Trigger 1',
-        properties: [propertyModel],
-        secure_properties: [propertyModel],
+        properties: { anyKey: 'anyValue' },
+        secure_properties: { anyKey: 'anyValue' },
         headers: { anyKey: 'anyValue' },
         body: { anyKey: 'anyValue' },
       };
@@ -719,8 +709,8 @@ describe('CdTektonPipelineV2', () => {
         // Construct the params object for operation createTektonPipelineRun
         const pipelineId = '94619026-912b-4d92-8f51-6c74f0692d90';
         const triggerName = 'testString';
-        const triggerProperties = [propertyModel];
-        const secureTriggerProperties = [propertyModel];
+        const triggerProperties = { anyKey: 'anyValue' };
+        const secureTriggerProperties = { anyKey: 'anyValue' };
         const triggerHeaders = { anyKey: 'anyValue' };
         const triggerBody = { anyKey: 'anyValue' };
         const trigger = pipelineRunTriggerModel;


### PR DESCRIPTION
## PR summary
Attempting to trigger a PipelineRun with additional `properties` or `secureProperties` supplied results in an error creating the PipelineRun. Fix the format being used for the properties.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
Attempting to trigger a PipelineRun with additional `properties` or `secureProperties` supplied will result in an error creating the PipelineRun. This is due to the wrong format being used for the properties, sending an Array instead of an Object.

## What is the new behavior?  
- Fix PipelineRun creation when supplying additional `properties` or `secureProperties`
- Update the integration test to account for this use case

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->