### PR TITLE
chore: clean up changelog for v2.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,34 +6,6 @@
 * fix release ([#75](https://github.com/IBM/continuous-delivery-node-sdk/issues/75)) ([a4c2b66](https://github.com/IBM/continuous-delivery-node-sdk/commit/a4c2b665297a3410186da254ad0bfe1e5ff2aee7))
 * upgrade to ibm-cloud-sdk-core@^5.4.10 ([#74](https://github.com/IBM/continuous-delivery-node-sdk/issues/74)) ([9c042cc](https://github.com/IBM/continuous-delivery-node-sdk/commit/9c042ccde9cd2c558034643fa97b42f19d86692e))
 
-## [2.1.7](https://github.com/IBM/continuous-delivery-node-sdk/compare/v2.1.6...v2.1.7) (2026-04-09)
-
-
-### Bug Fixes
-
-* fix release ([#75](https://github.com/IBM/continuous-delivery-node-sdk/issues/75)) ([a4c2b66](https://github.com/IBM/continuous-delivery-node-sdk/commit/a4c2b665297a3410186da254ad0bfe1e5ff2aee7))
-
-## [2.1.6](https://github.com/IBM/continuous-delivery-node-sdk/compare/v2.1.5...v2.1.6) (2026-04-09)
-
-
-### Bug Fixes
-
-* upgrade to ibm-cloud-sdk-core@^5.4.10 ([#74](https://github.com/IBM/continuous-delivery-node-sdk/issues/74)) ([9c042cc](https://github.com/IBM/continuous-delivery-node-sdk/commit/9c042ccde9cd2c558034643fa97b42f19d86692e))
-
-## [2.1.6](https://github.com/IBM/continuous-delivery-node-sdk/compare/v2.1.5...v2.1.6) (2026-04-09)
-
-
-### Bug Fixes
-
-* upgrade to ibm-cloud-sdk-core@^5.4.10 ([#74](https://github.com/IBM/continuous-delivery-node-sdk/issues/74)) ([9c042cc](https://github.com/IBM/continuous-delivery-node-sdk/commit/9c042ccde9cd2c558034643fa97b42f19d86692e))
-
-## [2.1.6](https://github.com/IBM/continuous-delivery-node-sdk/compare/v2.1.5...v2.1.6) (2026-04-09)
-
-
-### Bug Fixes
-
-* upgrade to ibm-cloud-sdk-core@^5.4.10 ([#74](https://github.com/IBM/continuous-delivery-node-sdk/issues/74)) ([9c042cc](https://github.com/IBM/continuous-delivery-node-sdk/commit/9c042ccde9cd2c558034643fa97b42f19d86692e))
-
 ## [2.1.5](https://github.com/IBM/continuous-delivery-node-sdk/compare/v2.1.4...v2.1.5) (2026-03-02)
 
 


### PR DESCRIPTION
## PR summary
Due to problems encountered with semantic-release when v2.1.6 was being released, the changelog file had a number of duplicate entries added to it and one erroneous 2.1.7 section added to it. Cleaning these up


## PR Checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

